### PR TITLE
Fix TensorFlow compatibility and memory release

### DIFF
--- a/deeplazy/core/tensorflow_lazy_model_patcher.py
+++ b/deeplazy/core/tensorflow_lazy_model_patcher.py
@@ -65,8 +65,7 @@ class TensorflowLazyModelPatcher:
                     if hasattr(layer, weight_name):
                         original_attrs[weight_name] = getattr(
                             layer, weight_name)
-                    tensor_on_device = tf.convert_to_tensor(
-                        weight_value.numpy())
+                    tensor_on_device = tf.convert_to_tensor(weight_value)
                     setattr(layer, weight_name, tensor_on_device)
 
             output = orig_call(*args, **kwargs)


### PR DESCRIPTION
## Summary
- fix `safe_open` import so TensorFlow tensors load correctly
- avoid redundant NumPy conversions when loading/patching TF layers
- release TensorFlow memory after unloading modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6841b2d98d748320bd016db0bb685ded